### PR TITLE
Changed from 'it should match with current locale' to 'should match w…

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -19,7 +19,7 @@ const jsonLocalization = {
 };
 
 describe('vasadu', () => {
-  it('it should match with current locale', () => {
+  it('should match with current locale', () => {
     const localization = vasadu(jsonLocalization, 'es');
 
     expect(localization.MENU_TOP_LEVEL).toEqual('Menú');


### PR DESCRIPTION
…ith current locale' to match language pattern